### PR TITLE
#3 Using Eclipse Vert.x API from a Quarkus Application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy-reactive-jackson'
     implementation enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
     implementation 'io.quarkus:quarkus-arc'
+    implementation "io.netty:netty-transport-native-epoll:4.1.69.Final:linux-x86_64"
+    implementation "io.netty:netty-transport-native-kqueue:4.1.69.Final:osx-x86_64"
     testImplementation 'io.quarkus:quarkus-junit5'
     testImplementation 'io.rest-assured:rest-assured'
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.log.level=DEBUG
+quarkus.vertx.prefer-native-transport=true


### PR DESCRIPTION
Native Transport Closed #3 